### PR TITLE
Fix EditorInspectorPlugin code example in inspector_plugins.rst

### DIFF
--- a/tutorials/plugins/editor/inspector_plugins.rst
+++ b/tutorials/plugins/editor/inspector_plugins.rst
@@ -115,7 +115,7 @@ specifically add :ref:`class_EditorProperty`-based controls.
     # my_inspector_plugin.gd
     extends EditorInspectorPlugin
 
-    var RandomIntEditor = preload("res://addons/my_inspector_plugin/random_int_editor.gd")
+    const RandomIntEditor = preload("res://addons/my_inspector_plugin/random_int_editor.gd")
 
 
     func _can_handle(object):


### PR DESCRIPTION
I didn't closely follow the tutorial, but while experimenting I got the error "`Invalid call. Nonexistent function 'new' in base 'Nil'.`"  from what in my case corresponded to the line `add_property_editor(path, RandomIntEditor.new())`.

I found https://stackoverflow.com/questions/75087375/nonexistent-function-instance-in-base-nil-in-godot-for-instancing-the-player, and replacing the `var` with a `const` fixed the error for me.

I don't know much about Godot, so it is possible that there was something else wrong with my code. The lines with the `preload()` and `new()` were the same for me, though.

If someone confirms that this what was wrong here, I'd do a search through the docs to see if any other code examples assign a `preload`ed script to a `var` instead of a `const`, if that helps.
